### PR TITLE
Fix patch permissions throughout all providers and show Edit dialog only when the provider supports task editing.

### DIFF
--- a/src/github_issues.rs
+++ b/src/github_issues.rs
@@ -95,6 +95,7 @@ impl TaskTrait for Task {
     }
     fn const_patch_policy(&self) -> PatchPolicy {
         PatchPolicy {
+            is_editable: false,
             available_states: Vec::new(),
             available_priorities: Vec::new(),
             available_due_items: Vec::new(),

--- a/src/gitlab_todo.rs
+++ b/src/gitlab_todo.rs
@@ -161,6 +161,7 @@ impl TaskTrait for Task {
 
     fn const_patch_policy(&self) -> PatchPolicy {
         PatchPolicy {
+            is_editable: false,
             available_states: vec![State::Uncompleted, State::Completed],
             available_priorities: Vec::new(),
             available_due_items: if self.issue.is_some() {

--- a/src/ical/task.rs
+++ b/src/ical/task.rs
@@ -9,7 +9,6 @@ use super::priority::TaskPriority;
 use crate::{
     project::Project as ProjectTrait,
     task::{DateTimeUtc, PatchPolicy, Priority, State, Task as TaskTrait},
-    task_patch::DuePatchItem,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -68,6 +67,7 @@ pub struct Task {
     pub properties: Vec<ical::property::Property>,
     pub href: String,
     pub task_type: TaskType,
+    pub patch_policy: PatchPolicy,
 
     pub uid: String,
     pub name: String,
@@ -165,11 +165,7 @@ impl TaskTrait for Task {
     }
 
     fn const_patch_policy(&self) -> PatchPolicy {
-        PatchPolicy {
-            available_states: vec![State::Uncompleted, State::InProgress, State::Completed],
-            available_priorities: Priority::values(),
-            available_due_items: DuePatchItem::values(),
-        }
+        self.patch_policy.clone()
     }
 
     fn description(&self) -> Option<String> {

--- a/src/obsidian/task.rs
+++ b/src/obsidian/task.rs
@@ -2,7 +2,8 @@
 
 use super::project::Project;
 use crate::project::Project as ProjectTrait;
-use crate::task::{DateTimeUtc, Priority, State as TaskState, Task as TaskTrait};
+use crate::task::{DateTimeUtc, PatchPolicy, Priority, State as TaskState, Task as TaskTrait};
+use crate::task_patch::DuePatchItem;
 use sha256::digest;
 use std::any::Any;
 use std::fmt::{self, Write};
@@ -178,6 +179,15 @@ impl TaskTrait for Task {
 
     fn labels(&self) -> Vec<String> {
         self.tags.clone()
+    }
+
+    fn const_patch_policy(&self) -> PatchPolicy {
+        PatchPolicy {
+            is_editable: true,
+            available_states: vec![TaskState::Uncompleted, TaskState::Completed, TaskState::InProgress],
+            available_priorities: Priority::values(),
+            available_due_items: DuePatchItem::values(),
+        }
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/task.rs
+++ b/src/task.rs
@@ -62,8 +62,9 @@ impl fmt::Display for Priority {
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct PatchPolicy {
+    pub is_editable: bool,
     pub available_states: Vec<State>,
     pub available_priorities: Vec<Priority>,
     pub available_due_items: Vec<DuePatchItem>,
@@ -117,6 +118,7 @@ pub trait Task: Send + Sync {
 
     fn const_patch_policy(&self) -> PatchPolicy {
         PatchPolicy {
+            is_editable: false,
             available_states: vec![State::Uncompleted, State::Completed, State::InProgress],
             available_priorities: Priority::values(),
             available_due_items: DuePatchItem::values(),

--- a/src/todoist/task.rs
+++ b/src/todoist/task.rs
@@ -175,6 +175,7 @@ impl TaskTrait for Task {
 
     fn const_patch_policy(&self) -> PatchPolicy {
         PatchPolicy {
+            is_editable: true,
             available_states: vec![TaskState::Uncompleted, TaskState::Completed],
             available_priorities: SUPPORTED_PRIORITIES.into(),
             available_due_items: DuePatchItem::values(),

--- a/src/ui/tasks_widget.rs
+++ b/src/ui/tasks_widget.rs
@@ -243,8 +243,10 @@ impl TasksWidget {
                         _ = add_task_rx.recv() => s.write().await.show_add_task_dialog(None).await,
                         _ = edit_task_rx.recv() => {
                             let mut s = s.write().await;
-                            let t = s.selected_task();
-                            s.show_add_task_dialog(t).await;
+                            if let Some(t) = s.selected_task()
+                                && t.patch_policy().is_editable {
+                                s.show_add_task_dialog(Some(t)).await;
+                            }
                         },
                         _ = open_task_link_rx.recv() => {
                             if let Some(t) = s.read().await.selected_task()


### PR DESCRIPTION
Closes #211 